### PR TITLE
running test_myo on brand new device no longer causes error

### DIFF
--- a/lib/myo.py
+++ b/lib/myo.py
@@ -58,7 +58,7 @@ class Myo(object):
 
         print('Firmware version: %d.%d.%d.%d' % (major, minor, patch, build))
 
-        return major > 0
+        return major > 0 && minor > 4
 
     def add_listener(self, listener):
         if self.ble is not None:


### PR DESCRIPTION
I have a brand new Myo. I ran test_myo.py on it and got the following output: 

Start Myo for Linux
Find Myo device...
Connected.
Firmware version: 1.0.2.2
Device name: Myo
Finished.
Traceback (most recent call last):
  File "test_myo.py", line 30, in <module>
    main()
  File "test_myo.py", line 19, in main
    myo.run()
  File "../lib/myo.py", line 51, in run
    self.ble.receive_packet(timeout)
  File "../lib/ble.py", line 23, in receive_packet
    self.notify_event(packet)
  File "../lib/ble.py", line 49, in notify_event
    listener.handle_data(p)
  File "../lib/device_listener.py", line 12, in handle_data
    data_type, value, address, _, _, _ = unpack('6B', payload)
  File "../lib/utilities.py", line 7, in unpack
    return struct.unpack('<' + fmt, *args)
struct.error: unpack requires a string argument of length 6

Upgrading my firmware fixed the error and all was well, but the error was pretty frustrating.